### PR TITLE
to 2.0

### DIFF
--- a/lib/cqm_validators/version.rb
+++ b/lib/cqm_validators/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CqmValidators
-  VERSION = '1.0.1.0'
+  VERSION = '2.0.0'
 end


### PR DESCRIPTION
Update version to 2.0
Pull requests into cqm-validators require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
