### PR TITLE
updated versioning language to reflect 3 digit versioning.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Then run bundler to grab all of the necessary gems:
 Versioning
 ==========
 
-Starting with version **2.0.0** released on !!date!!, cqm-validators versioning has the format **X.Y.Z**, where:
+Starting with version **2.0.0** released on 6/20/19, cqm-validators versioning has the format **X.Y.Z**, where:
 
 * **X** maps to a version of QRDA. See the table below to see the existing mapping to QRDA versions.
 

--- a/README.md
+++ b/README.md
@@ -18,15 +18,17 @@ Then run bundler to grab all of the necessary gems:
 Versioning
 ==========
 
-Starting with version **1.0.1.0** released on 5/22/2019, cqm-validators versioning has the format **W.X.Y.Z**, where:
+Starting with version **2.0.0** released on !!date!!, cqm-validators versioning has the format **X.Y.Z**, where:
 
-* **W** maps to a version of QRDA Category 1 and QRDA Category 3. See the table below to see the existing mapping to QRDA versions.
+* **X** maps to a version of QRDA. See the table below to see the existing mapping to QRDA versions.
 
-  | W | QRDA Cat 1 | QRDA Cat 3 |
+  | X | QRDA Cat 1 | QRDA Cat 3 |
   | --- | --- | --- |
-  | 1 | R1 STU5.1 | R1 STU2.1 |
+  | 2 | R1 STU5.1 | R1 STU2.1 |
 
-* **X.Y.Z** uses [SemVer](http://semver.org/) for versioning. **X.Y.Z** starts at 0.0.0 when **W** is incremented.
+* **Y** indicates major changes (incompatible API changes)
+
+* **Z** indicates minor changes (added functionality in a backwards-compatible manner) and patch changes (backwards-compatible bug fixes)
 
 For the versions available, see [tags on this repository](https://github.com/projecttacoma/cqm-validators/tags).
 


### PR DESCRIPTION
Versioning text now explains 3 digit versioning for Bonnie/Cypress shared libraries.


Pull requests into cqm-models require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Code diff has been done and been reviewed

**Bonnie Reviewer:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose

**Cypress Reviewer:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
