### PR TITLE
An 'exepected' NA Performace rate was returning an error message.  Fi…

### DIFF
--- a/lib/performance_rate_validator.rb
+++ b/lib/performance_rate_validator.rb
@@ -53,11 +53,11 @@ module CqmValidators
       numer_id = population_set.populations.NUMER.hqmf_id
       if expected == 'NA' && reported_result['PR']['nullFlavor'] != 'NA'
         build_error("Reported Performance Rate for Numerator #{numer_id} should be NA", '/', data[:file_name])
-      elsif reported_result['PR']['nullFlavor'] == 'NA'
+      elsif expected != 'NA' && reported_result['PR']['nullFlavor'] == 'NA'
         build_error("Reported Performance Rate for Numerator #{numer_id} should not be NA", '/', data[:file_name])
-      elsif reported_result['PR']['value'].split('.', 2).last.size > 6
+      elsif expected != 'NA' && reported_result['PR']['value'].split('.', 2).last.size > 6
         build_error('Reported Performance Rate SHALL not have a precision greater than .000001 ', '/', data[:file_name])
-      elsif (reported_result['PR']['value'].to_f - expected.round(6)).abs > 0.0000001
+      elsif expected != 'NA' && (reported_result['PR']['value'].to_f - expected.round(6)).abs > 0.0000001
         build_error("Reported Performance Rate of #{reported_result['PR']['value']} for Numerator #{numer_id} does not match expected"\
         " value of #{expected.round(6)}.", '/', data[:file_name])
       end

--- a/test/unit/performance_rate_validator_test.rb
+++ b/test/unit/performance_rate_validator_test.rb
@@ -39,6 +39,21 @@ class PerformanceRateValidatorTest < MiniTest::Test
     assert_equal 1, errors.length
   end
 
+  def test_performance_rate_equals_na_reported_na
+    errors_list = []
+    reported_result = {}
+    reported_result['DENOM'] = 1
+    reported_result['DENEX'] = 1
+    reported_result['DENEXCEP'] = 0
+    reported_result['NUMER'] = 0
+    reported_result['PR'] = {}
+    reported_result['PR']['nullFlavor'] = 'NA'
+    errors = @prcat3.check_performance_rates(reported_result, @proportion_pop_set, nil, file_name: 'test')
+    errors_list << errors unless errors.nil?
+    # 1 incorrect performance rate
+    assert_equal 0, errors_list.length
+  end
+
   def test_performance_rate_equals_na_reported_1
     errors_list = []
     reported_result = {}
@@ -49,7 +64,7 @@ class PerformanceRateValidatorTest < MiniTest::Test
     reported_result['PR'] = {}
     reported_result['PR']['nullFlavor'] = '1'
     errors = @prcat3.check_performance_rates(reported_result, @proportion_pop_set, nil, file_name: 'test')
-    errors_list << errors
+    errors_list << errors unless errors.nil?
     # 1 incorrect performance rate
     assert_equal 1, errors_list.length
   end
@@ -112,7 +127,7 @@ class PerformanceRateValidatorTest < MiniTest::Test
     reported_result['PR'] = {}
     reported_result['PR']['value'] = '1.285714'
     errors = @prcat3.check_performance_rates(reported_result, @proportion_pop_set, nil, file_name: 'test')
-    errors_list << errors
+    errors_list << errors unless errors.nil?
     # 1 incorrect performance rate
     assert_equal 1, errors_list.length
   end
@@ -127,7 +142,7 @@ class PerformanceRateValidatorTest < MiniTest::Test
     reported_result['PR'] = {}
     reported_result['PR']['value'] = '.285715'
     errors = @prcat3.check_performance_rates(reported_result, @proportion_pop_set, nil, file_name: 'test')
-    errors_list << errors
+    errors_list << errors unless errors.nil?
     # 1 incorrect performance rate
     assert_equal 1, errors_list.length
   end
@@ -142,7 +157,7 @@ class PerformanceRateValidatorTest < MiniTest::Test
     reported_result['PR'] = {}
     reported_result['PR']['value'] = '28.5714'
     errors = @prcat3.check_performance_rates(reported_result, @proportion_pop_set, nil, file_name: 'test')
-    errors_list << errors
+    errors_list << errors unless errors.nil?
     # 1 incorrect performance rate
     assert_equal 1, errors_list.length
   end
@@ -157,7 +172,7 @@ class PerformanceRateValidatorTest < MiniTest::Test
     reported_result['PR'] = {}
     reported_result['PR']['value'] = '.2857142857'
     errors = @prcat3.check_performance_rates(reported_result, @proportion_pop_set, nil, file_name: 'test')
-    errors_list << errors
+    errors_list << errors unless errors.nil?
     # 1 incorrect performance rate
     assert_equal 1, errors_list.length
   end
@@ -172,7 +187,7 @@ class PerformanceRateValidatorTest < MiniTest::Test
     reported_result['PR'] = {}
     reported_result['PR']['value'] = '.571428'
     errors = @prcat3.check_performance_rates(reported_result, @proportion_pop_set, nil, file_name: 'test')
-    errors_list << errors
+    errors_list << errors unless errors.nil?
     # 1 incorrect performance rate
     assert_equal 1, errors_list.length
   end


### PR DESCRIPTION
…xed nested elsif checks.

Pull requests into cqm-validators require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
