### PR TITLE
Measure validator only needs to find the ids of the measure.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -58,6 +58,9 @@ Metrics/PerceivedComplexity:
   Max: 10
 Naming/MethodParameterName:
   Enabled: false
+Naming/UncommunicativeMethodParamName:
+  Exclude:
+    - 'lib/reported_result_extractor.rb'
 Style/DateTime:
   Enabled: false
 Style/GuardClause:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.5
   Exclude:
     - bin/*
 Style/Documentation:
@@ -56,11 +56,10 @@ Metrics/CyclomaticComplexity:
   Max: 10
 Metrics/PerceivedComplexity:
   Max: 10
-Naming/MethodParameterName:
-  Enabled: false
-Naming/UncommunicativeMethodParamName:
   Exclude:
     - 'lib/reported_result_extractor.rb'
+Naming/MethodParameterName:
+  Enabled: false
 Style/DateTime:
   Enabled: false
 Style/GuardClause:

--- a/.simplecov
+++ b/.simplecov
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 SimpleCov.start do
   merge_timeout 3600
 end

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: ruby
 rvm:
   - 2.6
   - 2.5
-  - 2.4
-  - 2.3
 cache:
   - bundler
 sudo: required

--- a/cqm_validators.gemspec
+++ b/cqm_validators.gemspec
@@ -32,6 +32,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest-reporters'
   spec.add_development_dependency 'mongoid'
   spec.add_development_dependency 'overcommit'
-  spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rubocop', '~> 0.60'
+  spec.add_development_dependency 'rake', '>= 12.3.3'
+  spec.add_development_dependency 'rubocop', '~> 0.93'
 end

--- a/cqm_validators.gemspec
+++ b/cqm_validators.gemspec
@@ -22,6 +22,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version = '>= 2.5.0'
+
   spec.add_dependency 'nokogiri', '~>1.10'
 
   spec.add_development_dependency 'bundler'

--- a/lib/cqm_validators/version.rb
+++ b/lib/cqm_validators/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CqmValidators
-  VERSION = '3.0.0'
+  VERSION = '3.0.1'
 end

--- a/lib/measure_validator.rb
+++ b/lib/measure_validator.rb
@@ -12,7 +12,7 @@ module CqmValidators
       @errors = []
       @doc = get_document(file)
       @doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
-      measure_ids = CQM::Measure.all.map(&:hqmf_id)
+      measure_ids = CQM::Measure.pluck(:hqmf_id)
       doc_measure_ids = @doc.xpath(measure_selector).map(&:value).map(&:upcase)
       # list of all of the set ids in the QRDA
       doc_neutral_ids = @doc.xpath(neutral_measure_selector).map(&:value).map(&:upcase).sort


### PR DESCRIPTION
Pull requests into cqm-validators require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
