### PR TITLE
Measure validator only needs to find the ids of the measure

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,14 @@ Documentation:
 Lint/RescueException:
   Exclude:
     - 'lib/schematron/java_processor.rb'
+Layout/LineLength:
+  Max: 150
+  Exclude:
+    - 'test/**/*'
+    # TODO: remove exclusions below this line as line length is fixed
+    - 'lib/reported_result_extractor.rb'
+    - 'lib/data_validator.rb'
+    - 'lib/measure_validator.rb'
 Metrics/AbcSize:
   # The ABC size is a calculated magnitude, so this number can be a Fixnum or
   # a Float.
@@ -25,14 +33,6 @@ Metrics/ClassLength:
     - 'test/**/*'
     # TODO: remove exclusions below this line as Class length is fixed
     - 'lib/qrda_qdm_template_validator.rb'
-Metrics/LineLength:
-  Max: 150
-  Exclude:
-    - 'test/**/*'
-    # TODO: remove exclusions below this line as line length is fixed
-    - 'lib/reported_result_extractor.rb'
-    - 'lib/data_validator.rb'
-    - 'lib/measure_validator.rb'
 Metrics/MethodLength:
   CountComments: false  # count full line comments?
   Max: 20

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.5
   Exclude:
     - bin/*
 Documentation:
@@ -50,7 +50,9 @@ Metrics/CyclomaticComplexity:
   Max: 10
 Metrics/PerceivedComplexity:
   Max: 10
-Naming/UncommunicativeMethodParamName:
+  Exclude:
+    - 'lib/reported_result_extractor.rb'
+Naming/MethodParameterName:
   Enabled: false
 Style/DateTime:
   Enabled: false

--- a/.simplecov
+++ b/.simplecov
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 SimpleCov.start do
   merge_timeout 3600
 end

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: ruby
 rvm:
   - 2.6
   - 2.5
-  - 2.4
-  - 2.3
 cache:
   - bundler
 sudo: required

--- a/cqm_validators.gemspec
+++ b/cqm_validators.gemspec
@@ -22,7 +22,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'nokogiri', '~>1.10.3'
+  spec.required_ruby_version = '>= 2.5.0'
+
+  spec.add_dependency 'nokogiri', '~>1.10'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'byebug'
@@ -30,6 +32,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest-reporters'
   spec.add_development_dependency 'mongoid'
   spec.add_development_dependency 'overcommit'
-  spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rubocop', '~> 0.60'
+  spec.add_development_dependency 'rake', '>= 12.3.3'
+  spec.add_development_dependency 'rubocop', '~> 0.93'
 end

--- a/lib/cqm_validators/version.rb
+++ b/lib/cqm_validators/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CqmValidators
-  VERSION = '2.0.1'
+  VERSION = '2.0.2'
 end

--- a/lib/measure_validator.rb
+++ b/lib/measure_validator.rb
@@ -12,7 +12,7 @@ module CqmValidators
       @errors = []
       @doc = get_document(file)
       @doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
-      measure_ids = CQM::Measure.all.map(&:hqmf_id)
+      measure_ids = CQM::Measure.pluck(:hqmf_id)
       doc_measure_ids = @doc.xpath(measure_selector).map(&:value).map(&:upcase)
       # list of all of the set ids in the QRDA
       doc_neutral_ids = @doc.xpath(neutral_measure_selector).map(&:value).map(&:upcase).sort

--- a/lib/performance_rate_validator.rb
+++ b/lib/performance_rate_validator.rb
@@ -52,13 +52,13 @@ module CqmValidators
       expected = calculate_performance_rates(reported_result)
       numer_id = population_set.populations.NUMER.hqmf_id
       if expected == 'NA' && reported_result['PR']['nullFlavor'] != 'NA'
-        return build_error("Reported Performance Rate for Numerator #{numer_id} should be NA", '/', data[:file_name])
-      elsif reported_result['PR']['nullFlavor'] == 'NA'
-        return build_error("Reported Performance Rate for Numerator #{numer_id} should not be NA", '/', data[:file_name])
-      elsif reported_result['PR']['value'].split('.', 2).last.size > 6
-        return build_error('Reported Performance Rate SHALL not have a precision greater than .000001 ', '/', data[:file_name])
-      elsif (reported_result['PR']['value'].to_f - expected.round(6)).abs > 0.0000001
-        return build_error("Reported Performance Rate of #{reported_result['PR']['value']} for Numerator #{numer_id} does not match expected"\
+        build_error("Reported Performance Rate for Numerator #{numer_id} should be NA", '/', data[:file_name])
+      elsif expected != 'NA' && reported_result['PR']['nullFlavor'] == 'NA'
+        build_error("Reported Performance Rate for Numerator #{numer_id} should not be NA", '/', data[:file_name])
+      elsif expected != 'NA' && reported_result['PR']['value'].split('.', 2).last.size > 6
+        build_error('Reported Performance Rate SHALL not have a precision greater than .000001 ', '/', data[:file_name])
+      elsif expected != 'NA' && (reported_result['PR']['value'].to_f - expected.round(6)).abs > 0.0000001
+        build_error("Reported Performance Rate of #{reported_result['PR']['value']} for Numerator #{numer_id} does not match expected"\
         " value of #{expected.round(6)}.", '/', data[:file_name])
       end
     end

--- a/test/unit/performance_rate_validator_test.rb
+++ b/test/unit/performance_rate_validator_test.rb
@@ -39,6 +39,21 @@ class PerformanceRateValidatorTest < MiniTest::Test
     assert_equal 1, errors.length
   end
 
+  def test_performance_rate_equals_na_reported_na
+    errors_list = []
+    reported_result = {}
+    reported_result['DENOM'] = 1
+    reported_result['DENEX'] = 1
+    reported_result['DENEXCEP'] = 0
+    reported_result['NUMER'] = 0
+    reported_result['PR'] = {}
+    reported_result['PR']['nullFlavor'] = 'NA'
+    errors = @prcat3.check_performance_rates(reported_result, @proportion_pop_set, nil, file_name: 'test')
+    errors_list << errors unless errors.nil?
+    # 1 incorrect performance rate
+    assert_equal 0, errors_list.length
+  end
+
   def test_performance_rate_equals_na_reported_1
     errors_list = []
     reported_result = {}
@@ -49,7 +64,7 @@ class PerformanceRateValidatorTest < MiniTest::Test
     reported_result['PR'] = {}
     reported_result['PR']['nullFlavor'] = '1'
     errors = @prcat3.check_performance_rates(reported_result, @proportion_pop_set, nil, file_name: 'test')
-    errors_list << errors
+    errors_list << errors unless errors.nil?
     # 1 incorrect performance rate
     assert_equal 1, errors_list.length
   end
@@ -112,7 +127,7 @@ class PerformanceRateValidatorTest < MiniTest::Test
     reported_result['PR'] = {}
     reported_result['PR']['value'] = '1.285714'
     errors = @prcat3.check_performance_rates(reported_result, @proportion_pop_set, nil, file_name: 'test')
-    errors_list << errors
+    errors_list << errors unless errors.nil?
     # 1 incorrect performance rate
     assert_equal 1, errors_list.length
   end
@@ -127,7 +142,7 @@ class PerformanceRateValidatorTest < MiniTest::Test
     reported_result['PR'] = {}
     reported_result['PR']['value'] = '.285715'
     errors = @prcat3.check_performance_rates(reported_result, @proportion_pop_set, nil, file_name: 'test')
-    errors_list << errors
+    errors_list << errors unless errors.nil?
     # 1 incorrect performance rate
     assert_equal 1, errors_list.length
   end
@@ -142,7 +157,7 @@ class PerformanceRateValidatorTest < MiniTest::Test
     reported_result['PR'] = {}
     reported_result['PR']['value'] = '28.5714'
     errors = @prcat3.check_performance_rates(reported_result, @proportion_pop_set, nil, file_name: 'test')
-    errors_list << errors
+    errors_list << errors unless errors.nil?
     # 1 incorrect performance rate
     assert_equal 1, errors_list.length
   end
@@ -157,7 +172,7 @@ class PerformanceRateValidatorTest < MiniTest::Test
     reported_result['PR'] = {}
     reported_result['PR']['value'] = '.2857142857'
     errors = @prcat3.check_performance_rates(reported_result, @proportion_pop_set, nil, file_name: 'test')
-    errors_list << errors
+    errors_list << errors unless errors.nil?
     # 1 incorrect performance rate
     assert_equal 1, errors_list.length
   end
@@ -172,7 +187,7 @@ class PerformanceRateValidatorTest < MiniTest::Test
     reported_result['PR'] = {}
     reported_result['PR']['value'] = '.571428'
     errors = @prcat3.check_performance_rates(reported_result, @proportion_pop_set, nil, file_name: 'test')
-    errors_list << errors
+    errors_list << errors unless errors.nil?
     # 1 incorrect performance rate
     assert_equal 1, errors_list.length
   end


### PR DESCRIPTION
Pull requests into cqm-validators require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
