### PR TITLE
support numex

### DIFF
--- a/lib/performance_rate_validator.rb
+++ b/lib/performance_rate_validator.rb
@@ -35,10 +35,13 @@ module CqmValidators
       denexcep = 0
       denom = 0
       numer = 0
+      numex = 0
       denex = reported_result['DENEX'] unless reported_result['DENEX'].nil?
       denexcep = reported_result['DENEXCEP'] unless reported_result['DENEXCEP'].nil?
       denom = reported_result['DENOM'] unless reported_result['DENOM'].nil?
       numer = reported_result['NUMER'] unless reported_result['NUMER'].nil?
+      numex = reported_result['NUMEX'] unless reported_result['NUMEX'].nil?
+      numer -= numex
       denom = denom - denex - denexcep
       pr = if denom.zero?
              'NA'


### PR DESCRIPTION
Pull requests into cqm-validators require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
