### PR TITLE
support multiple observations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -60,6 +60,8 @@ Metrics/PerceivedComplexity:
     - 'lib/reported_result_extractor.rb'
 Naming/MethodParameterName:
   Enabled: false
+Metrics/ParameterLists:
+  Max: 6
 Style/DateTime:
   Enabled: false
 Style/GuardClause:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -60,8 +60,6 @@ Metrics/PerceivedComplexity:
     - 'lib/reported_result_extractor.rb'
 Naming/MethodParameterName:
   Enabled: false
-Metrics/ParameterLists:
-  Max: 6
 Style/DateTime:
   Enabled: false
 Style/GuardClause:

--- a/lib/cqm_validators/version.rb
+++ b/lib/cqm_validators/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CqmValidators
-  VERSION = '3.0.1'
+  VERSION = '3.1.0'
 end

--- a/lib/reported_result_extractor.rb
+++ b/lib/reported_result_extractor.rb
@@ -36,6 +36,7 @@ module CqmValidators
     end
 
     def get_measure_components(n, population_set, stratification_id)
+      # observations are a hash of population/value. For example {"DENOM"=>108.0, "NUMER"=>2}
       results = { supplemental_data: {}, observations: {} }
       stratification = stratification_id ? population_set.stratifications.where(stratification_id: stratification_id).first.hqmf_id : nil
       ALL_POPULATION_CODES.each do |pop_code|
@@ -54,7 +55,9 @@ module CqmValidators
 
     def get_observed_values(results, n, pop_code, population_set, stratification)
       statement_name = population_set.populations[pop_code]['statement_name']
+      # look to see if there is an observation that corresponds to the specific statement_name
       statement_observation = population_set.observations.select { |obs| obs.observation_parameter.statement_name == statement_name }
+      # return unless an observation is found
       unless statement_observation.empty?
         hqmf_id = population_set.populations[pop_code]['hqmf_id']
         results[:observations][pop_code] = extract_cv_value(n, statement_observation.first.hqmf_id, hqmf_id, pop_code, stratification)

--- a/lib/reported_result_extractor.rb
+++ b/lib/reported_result_extractor.rb
@@ -8,7 +8,7 @@ module CqmValidators
     # returns nil if nothing matching is found
     # returns a hash with the values of the populations filled out along with the population_ids added to the result
 
-    ALL_POPULATION_CODES = %w[IPP DENOM NUMER NUMEX DENEX DENEXCEP MSRPOPL MSRPOPLEX OBSERV].freeze
+    ALL_POPULATION_CODES = %w[IPP DENOM NUMER NUMEX DENEX DENEXCEP MSRPOPL MSRPOPLEX].freeze
 
     def extract_results_by_ids(measure, poulation_set_id, doc, stratification_id = nil)
       results = nil
@@ -20,7 +20,7 @@ module CqmValidators
       end
 
       nodes.each do |n|
-        results = get_measure_components(n, measure.population_sets.where(population_set_id: poulation_set_id).first, stratification_id)
+        results = get_measure_components(n, measure.population_sets.where(population_set_id: poulation_set_id).first, stratification_id, measure.measure_attributes)
         break if !results.nil? || (!results.nil? && !results.empty?)
       end
       return nil if results.nil?
@@ -35,22 +35,14 @@ module CqmValidators
       doc.xpath(xpath_measures)
     end
 
-    def get_measure_components(n, population_set, stratification_id)
-      results = { supplemental_data: {} }
+    def get_measure_components(n, population_set, stratification_id, measure_attributes)
+      results = { supplemental_data: {}, observations: {} }
       stratification = stratification_id ? population_set.stratifications.where(stratification_id: stratification_id).first.hqmf_id : nil
       ALL_POPULATION_CODES.each do |pop_code|
-        next unless population_set.populations[pop_code] || pop_code == 'OBSERV'
+        next unless population_set.populations[pop_code]
 
-        val = nil
-        sup = nil
-        if pop_code == 'OBSERV'
-          next unless population_set.populations['MSRPOPL']
-
-          msrpopl = population_set.populations['MSRPOPL']['hqmf_id']
-          val, sup = extract_cv_value(n, population_set.observations.first.hqmf_id, msrpopl, stratification)
-        else
-          val, sup, pr = extract_component_value(n, pop_code, population_set.populations[pop_code]['hqmf_id'], stratification)
-        end
+        get_observed_values(results, n, pop_code, population_set, measure_attributes, stratification) if measure_attributes
+        val, sup, pr = extract_component_value(n, pop_code, population_set.populations[pop_code]['hqmf_id'], stratification)
         unless val.nil?
           results[pop_code] = val
           results[:supplemental_data][pop_code] = sup
@@ -60,8 +52,18 @@ module CqmValidators
       results
     end
 
-    def extract_cv_value(node, id, msrpopl, strata = nil)
-      xpath_observation = %( cda:component/cda:observation[./cda:value[@code = "MSRPOPL"] and ./cda:reference/cda:externalObservation/cda:id[#{translate('@root')}='#{msrpopl.upcase}']])
+    def get_observed_values(results, n, pop_code, population_set, measure_attributes, stratification)
+      statement_name = population_set.populations[pop_code]['statement_name']
+      obs_pop_code = measure_attributes.select { |ma| ma['name'] == statement_name }.first['code']
+      statement_observation = population_set.observations.select { |obs| obs.observation_parameter.statement_name == statement_name }
+      unless statement_observation.empty?
+        hqmf_id = population_set.populations[pop_code]['hqmf_id']
+        results[:observations][obs_pop_code] = extract_cv_value(n, statement_observation.first.hqmf_id, hqmf_id, pop_code, stratification)
+      end
+    end
+
+    def extract_cv_value(node, id, msrpopl, pop_code, strata = nil)
+      xpath_observation = %( cda:component/cda:observation[./cda:value[@code = "#{pop_code}"] and ./cda:reference/cda:externalObservation/cda:id[#{translate('@root')}='#{msrpopl.upcase}']])
       cv = node.at_xpath(xpath_observation)
       return nil unless cv
 
@@ -73,7 +75,7 @@ module CqmValidators
       else
         val = get_cv_value(cv, id)
       end
-      [val, (strata.nil? ? extract_supplemental_data(cv) : nil)]
+      val
     end
 
     def extract_component_value(node, code, id, strata = nil)

--- a/lib/reported_result_extractor.rb
+++ b/lib/reported_result_extractor.rb
@@ -20,7 +20,7 @@ module CqmValidators
       end
 
       nodes.each do |n|
-        results = get_measure_components(n, measure.population_sets.where(population_set_id: poulation_set_id).first, stratification_id, measure.measure_attributes)
+        results = get_measure_components(n, measure.population_sets.where(population_set_id: poulation_set_id).first, stratification_id, measure.population_criteria)
         break if !results.nil? || (!results.nil? && !results.empty?)
       end
       return nil if results.nil?
@@ -35,13 +35,13 @@ module CqmValidators
       doc.xpath(xpath_measures)
     end
 
-    def get_measure_components(n, population_set, stratification_id, measure_attributes)
+    def get_measure_components(n, population_set, stratification_id, population_criteria)
       results = { supplemental_data: {}, observations: {} }
       stratification = stratification_id ? population_set.stratifications.where(stratification_id: stratification_id).first.hqmf_id : nil
       ALL_POPULATION_CODES.each do |pop_code|
         next unless population_set.populations[pop_code]
 
-        get_observed_values(results, n, pop_code, population_set, measure_attributes, stratification) if measure_attributes
+        get_observed_values(results, n, pop_code, population_set, population_criteria, stratification) if population_criteria
         val, sup, pr = extract_component_value(n, pop_code, population_set.populations[pop_code]['hqmf_id'], stratification)
         unless val.nil?
           results[pop_code] = val
@@ -52,9 +52,10 @@ module CqmValidators
       results
     end
 
-    def get_observed_values(results, n, pop_code, population_set, measure_attributes, stratification)
+    def get_observed_values(results, n, pop_code, population_set, population_criteria, stratification)
       statement_name = population_set.populations[pop_code]['statement_name']
-      obs_pop_code = measure_attributes.select { |ma| ma['name'] == statement_name }.first['code']
+      statement_hqmf_id = population_set.populations[pop_code]['hqmf_id']
+      obs_pop_code = population_criteria.values.detect { |pc| pc['hqmf_id'] = statement_hqmf_id }['type']
       statement_observation = population_set.observations.select { |obs| obs.observation_parameter.statement_name == statement_name }
       unless statement_observation.empty?
         hqmf_id = population_set.populations[pop_code]['hqmf_id']

--- a/test/unit/reported_result_extractor_test.rb
+++ b/test/unit/reported_result_extractor_test.rb
@@ -18,7 +18,7 @@ class ReportedResultExtractorTest < Minitest::Test
     results = extract_results_by_ids(measure, 'PopulationCriteria1', doc)
 
     # make sure the OBSERV result (the actual CV value) equals the value from the XML
-    assert_equal results['OBSERV'], 15.0
+    assert_equal results[:observations].values.first, 15.0
   end
 
   def test_should_return_the_correct_reported_result_for_a_stratified_cv_value
@@ -29,6 +29,6 @@ class ReportedResultExtractorTest < Minitest::Test
     results = extract_results_by_ids(measure, 'PopulationCriteria1', doc, 'PopulationCriteria1 - Stratification 3')
 
     # make sure the OBSERV result (the actual CV value) equals the value from the XML
-    assert_equal results['OBSERV'], 15.0
+    assert_equal results[:observations].values.first, 15.0
   end
 end


### PR DESCRIPTION
Pull requests into cqm-validators require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
