### PR TITLE
Rails 6

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.4
   Exclude:
     - bin/*
 Style/Documentation:

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,6 @@ gemspec development_group: :test
 
 group :test do
   gem 'codecov', require: false
-  gem 'cqm-models', git: 'https://github.com/projecttacoma/cqm-models.git', branch: 'rails_6'
+  gem 'cqm-models', '~> 3.0'
   gem 'simplecov', require: false
 end

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,6 @@ gemspec development_group: :test
 
 group :test do
   gem 'codecov', require: false
-  gem 'cqm-models', git: 'https://github.com/projecttacoma/cqm-models.git', branch: 'master'
+  gem 'cqm-models', git: 'https://github.com/projecttacoma/cqm-models.git', branch: 'rails_6'
   gem 'simplecov', require: false
 end

--- a/cqm_validators.gemspec
+++ b/cqm_validators.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.5.0'
+  spec.required_ruby_version = '>= 2.4.0'
 
   spec.add_dependency 'nokogiri', '>= 1.8.5', '< 1.12.0'
 

--- a/cqm_validators.gemspec
+++ b/cqm_validators.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.5.0'
 
-  spec.add_dependency 'nokogiri', '~>1.10'
+  spec.add_dependency 'nokogiri', '>= 1.8.5', '< 1.12.0'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'byebug'

--- a/lib/cqm_validators/version.rb
+++ b/lib/cqm_validators/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CqmValidators
-  VERSION = '3.1.0'
+  VERSION = '3.1.1'
 end


### PR DESCRIPTION
Pull requests into cqm-validators require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
