### PR TITLE
bump nokogiri in case of security vulnerability

### DIFF
--- a/cqm_validators.gemspec
+++ b/cqm_validators.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.4.0'
 
-  spec.add_dependency 'nokogiri', '>= 1.8.5', '< 1.12.0'
+  spec.add_dependency 'nokogiri', '>= 1.8.5', '< 1.13.0'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'byebug'

--- a/lib/cqm_validators/version.rb
+++ b/lib/cqm_validators/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CqmValidators
-  VERSION = '3.1.1'
+  VERSION = '3.1.2'
 end

--- a/lib/validators.rb
+++ b/lib/validators.rb
@@ -8,6 +8,7 @@ require_relative 'measure_validator'
 require_relative 'data_validator'
 require_relative 'performance_rate_validator'
 require_relative 'qrda_qdm_template_validator'
+require 'singleton'
 
 module CqmValidators
   CDA_SDTC_SCHEMA = 'lib/schema/infrastructure/cda/CDA_SDTC.xsd'


### PR DESCRIPTION
Pull requests into cqm-validators require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
