### PR TITLE
Different Population Sets can have diffrent observations values.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -58,6 +58,10 @@ Metrics/PerceivedComplexity:
   Max: 10
   Exclude:
     - 'lib/reported_result_extractor.rb'
+Metrics/ParameterLists:
+  Max: 5
+  Exclude:
+    - 'lib/reported_result_extractor.rb'
 Naming/MethodParameterName:
   Enabled: false
 Style/DateTime:

--- a/lib/reported_result_extractor.rb
+++ b/lib/reported_result_extractor.rb
@@ -20,8 +20,8 @@ module CqmValidators
       end
 
       nodes.each do |n|
-        popset_index = measure.population_sets_and_stratifications_for_measure.find_index do |pop_set|
-          pop_set[:population_set_id] == poulation_set_id
+        popset_index = measure.population_sets.map(&:population_set_id).find_index do |pop_set|
+          pop_set == poulation_set_id
         end
         results = get_measure_components(n, measure.population_sets.where(population_set_id: poulation_set_id).first, stratification_id, popset_index)
         break if !results.nil? || (!results.nil? && !results.empty?)


### PR DESCRIPTION
Look up the right one by index

Pull requests into cqm-validators require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
