### PR TITLE
Increment Version to 4.0.3.  Safe navigation in Performance Rate Vali…

### DIFF
--- a/lib/cqm_validators/version.rb
+++ b/lib/cqm_validators/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CqmValidators
-  VERSION = '4.0.2'
+  VERSION = '4.0.3'
 end

--- a/lib/performance_rate_validator.rb
+++ b/lib/performance_rate_validator.rb
@@ -17,6 +17,8 @@ module CqmValidators
       measure_ids = document.xpath(measure_selector).map(&:value).map(&:upcase)
       measure_ids.each do |measure_id|
         measure = CQM::Measure.where(hqmf_id: measure_id).first
+        next unless measure
+
         measure.population_sets.each do |population_set|
           reported_result, = extract_results_by_ids(measure, population_set.population_set_id, document)
           # only check performace rate when there is one


### PR DESCRIPTION
…dator

Pull requests into cqm-validators require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
