### PR TITLE
Support "OTH" genders in QRDA III document

### DIFF
--- a/lib/reported_result_extractor.rb
+++ b/lib/reported_result_extractor.rb
@@ -158,6 +158,8 @@ module CqmValidators
           if value.at_xpath('./@nullFlavor')
             if supp == 'PAYER' && value['xsi:type'] == 'CD' && value['nullFlavor'] == 'OTH' && value.at_xpath('cda:translation') && value.at_xpath('cda:translation')['code']
               key_hash[value.at_xpath('cda:translation')['code']] = count
+            elsif supp == 'SEX' && value['xsi:type'] == 'CD' && value['nullFlavor'] == 'OTH' && value.at_xpath('cda:translation') && value.at_xpath('cda:translation')['code']
+              key_hash[value.at_xpath('cda:translation')['code']] = count
             else
               key_hash['UNK'] = count
             end


### PR DESCRIPTION
Pull requests into cqm-validators require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
